### PR TITLE
Fix ATE2.md pour macOS Big Sur

### DIFF
--- a/Documents/ATE2.md
+++ b/Documents/ATE2.md
@@ -79,7 +79,7 @@ GoLink /entry:Start /console kernel32.dll programme.obj
 
 ```
 nasm -f macho64 programme.asm -o programme.obj
-ld programme.obj -o programme -lSystem
+ld programme.obj -o programme -lSystem -L /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib/
 ```
 
 ### Linux


### PR DESCRIPTION
Avec macOS 11, la librairie `libSystem.dylib`, ainsi que plusieurs autre librairies, a été déplacé. Il faut donc spécifier le nouvel emplacement avec `-L /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib/`, car le lieur ld n'a pas ce répertoire dans ces search-paths de défauts, et le répertoire n'est pas dans le $PATH.